### PR TITLE
Add stratis-cli archlinux package

### DIFF
--- a/users/index.html
+++ b/users/index.html
@@ -135,7 +135,7 @@ frameworks, itemized below. Please file a GitHub <a href="https://github.com/str
 you would like any others to be added to the list.</p>
 <h1 id="supported-operating-systems">Supported Operating Systems</h1>
 <ul>
-<li>Arch Linux: <a href="https://archlinux.org/packages/community/x86_64/stratisd/">https://archlinux.org/packages/community/x86_64/stratisd/</a></li>
+<li>Arch Linux: <a href="https://archlinux.org/packages/community/x86_64/stratisd/">https://archlinux.org/packages/community/x86_64/stratisd/</a>, <a href="https://archlinux.org/packages/community/any/stratis-cli/">https://archlinux.org/packages/community/any/stratis-cli/</a></li>
 <li>Fedora: <a href="https://src.fedoraproject.org/rpms/stratisd/">https://src.fedoraproject.org/rpms/stratisd/</a>, <a href="https://src.fedoraproject.org/rpms/stratis-cli">https://src.fedoraproject.org/rpms/stratis-cli</a></li>
 </ul>
 <h1 id="clients">Clients</h1>


### PR DESCRIPTION
Added the stratis-cli package url to users/index.html to let users know that the stratis-cli is also available for archlinux